### PR TITLE
Exclude child quote items for configurable product explicitly

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -234,6 +234,14 @@ class Taxjar_SalesTax_Model_Smartcalcs
                 $discount = (float) $item->getDiscountAmount();
                 $taxCode = '';
 
+
+                $confTypeId = Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE;
+                if ($item->getParentItem()
+                    && $item->getParentItem()->getProduct()->getTypeId() === $confTypeId
+                ) {
+                    continue;
+                }
+
                 if ($item->getProductType() == Mage_Catalog_Model_Product_Type::TYPE_BUNDLE) {
                     $parentQuantities[$id] = $quantity;
 


### PR DESCRIPTION
As a result of customisations quote items that usually have 0 price (for example configurable product quote item that corresponds to child), could have non zero price. It makes `\Taxjar_SalesTax_Model_Smartcalcs::_getLineItems` working incorrect (you have 2 items in basket, but tax is calculated for 4 items).