### PR TITLE
Apply config changes to TaxJar enabled websites/stores only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Backup.php
+++ b/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Backup.php
@@ -19,8 +19,33 @@
  * Backup Dropdown Renderer
  * Handle state based on presence of API token
  */
-class Taxjar_SalesTax_Block_Adminhtml_Backup extends Mage_Adminhtml_Block_System_Config_Form_Field
+class Taxjar_SalesTax_Block_Adminhtml_Backup extends Taxjar_SalesTax_Block_Adminhtml_Field
 {
+    const CACHE_KEY = 'taxjar_salestax_config_backup';
+    const CACHE_TAG = ['TAXJAR_SALESTAX_BACKUP'];
+
+    /**
+     * @return string
+     */
+    public function getFieldCacheKey()
+    {
+        return self::CACHE_KEY;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTagKey()
+    {
+        return self::CACHE_TAG;
+    }
+
+    /**
+     * @param Varien_Data_Form_Element_Abstract $element
+     *
+     * @return string
+     * @throws Zend_Cache_Exception
+     */
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {
         $apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));
@@ -30,11 +55,5 @@ class Taxjar_SalesTax_Block_Adminhtml_Backup extends Mage_Adminhtml_Block_System
         }
 
         return parent::_getElementHtml($element);
-    }
-
-    protected function _cacheElementValue(Varien_Data_Form_Element_Abstract $element)
-    {
-        $elementValue = (string) $element->getValue();
-        Mage::app()->getCache()->save($elementValue, 'taxjar_salestax_config_backup', array('TAXJAR_SALESTAX_BACKUP'), null);
     }
 }

--- a/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Enabled.php
+++ b/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Enabled.php
@@ -19,8 +19,33 @@
  * Config Enabled Dropdown Renderer
  * Handle state based on presence of API token
  */
-class Taxjar_SalesTax_Block_Adminhtml_Enabled extends Mage_Adminhtml_Block_System_Config_Form_Field
+class Taxjar_SalesTax_Block_Adminhtml_Enabled extends Taxjar_SalesTax_Block_Adminhtml_Field
 {
+    const CACHE_KEY = 'taxjar_salestax_config_enabled';
+    const CACHE_TAG = ['TAXJAR_SALESTAX_ENABLED'];
+
+    /**
+     * @return string
+     */
+    public function getFieldCacheKey()
+    {
+        return self::CACHE_KEY;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTagKey()
+    {
+        return self::CACHE_TAG;
+    }
+
+    /**
+     * @param Varien_Data_Form_Element_Abstract $element
+     *
+     * @return string
+     * @throws Zend_Cache_Exception
+     */
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {
         $apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));
@@ -32,11 +57,5 @@ class Taxjar_SalesTax_Block_Adminhtml_Enabled extends Mage_Adminhtml_Block_Syste
         }
 
         return parent::_getElementHtml($element);
-    }
-
-    protected function _cacheElementValue(Varien_Data_Form_Element_Abstract $element)
-    {
-        $elementValue = (string) $element->getValue();
-        Mage::app()->getCache()->save($elementValue, 'taxjar_salestax_config_enabled', array('TAXJAR_SALESTAX_ENABLED'), null);
     }
 }

--- a/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Field.php
+++ b/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Field.php
@@ -1,0 +1,35 @@
+<?php
+
+abstract class Taxjar_SalesTax_Block_Adminhtml_Field extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    use Taxjar_SalesTax_Trait_ConfigScope;
+
+    /**
+     * @return string
+     */
+    public abstract function getFieldCacheKey();
+
+    /**
+     * @return array
+     */
+    public abstract function getTagKey();
+
+    /**
+     * @param Varien_Data_Form_Element_Abstract $element
+     *
+     * @throws Zend_Cache_Exception
+     */
+    protected function _cacheElementValue(Varien_Data_Form_Element_Abstract $element)
+    {
+        $elementValue = (string) $element->getValue();
+
+        // UPDATE NOTE: include scope code into cache key
+        Mage::app()->getCache()->save(
+            $elementValue,
+            $this->getFieldCacheKey() . '_' . $this->getScopeCode(),
+            $this->getTagKey(),
+            null
+        );
+        // END UPDATE
+    }
+}

--- a/app/code/community/Taxjar/SalesTax/Model/Configuration.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Configuration.php
@@ -21,6 +21,11 @@
  */
 class Taxjar_SalesTax_Model_Configuration
 {
+    use Taxjar_SalesTax_Trait_ConfigScope;
+
+    const DISPLAY_TAX_EXCLUSIVE = 1;
+    const DISPLAY_TAX_INCLUSIVE = 2;
+
     /**
      * Sets shipping taxability in Magento
      *
@@ -63,16 +68,21 @@ class Taxjar_SalesTax_Model_Configuration
      */
     public function setDisplaySettings()
     {
-        $settings = array(
+        $settings = [
             'tax/display/type',
             'tax/display/shipping',
             'tax/cart_display/price',
             'tax/cart_display/subtotal',
             'tax/cart_display/shipping'
-        );
+        ];
 
         foreach ($settings as $setting) {
-            $this->_setConfig($setting, 1);
+            $this->_setConfig(
+                $setting,
+                self::DISPLAY_TAX_EXCLUSIVE,
+                $this->getScope(),
+                $this->getScopeId()
+            );
         }
     }
 
@@ -172,11 +182,14 @@ class Taxjar_SalesTax_Model_Configuration
      *
      * @param string $path
      * @param string $value
+     * @param string $scope
+     * @param int    $scopeId
+     *
      * @return void
      */
-    private function _setConfig($path, $value)
+    private function _setConfig($path, $value, $scope = 'default', $scopeId = 0)
     {
-        Mage::getConfig()->saveConfig($path, $value, 'default', 0);
+        Mage::getConfig()->saveConfig($path, $value, $scope, $scopeId);
     }
 
     /**

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ConfigChanged.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ConfigChanged.php
@@ -15,38 +15,65 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
+use Taxjar_SalesTax_Block_Adminhtml_Enabled as Enabled;
+use Taxjar_SalesTax_Block_Adminhtml_Backup as Backup;
+
 class Taxjar_SalesTax_Model_Observer_ConfigChanged
 {
+    use Taxjar_SalesTax_Trait_ConfigScope;
+
+    const CONFIG_ENABLED = 'tax/taxjar/enabled';
+    const CONFIG_BACKUP  = 'tax/taxjar/backup';
+
+    /**
+     * @param Varien_Event_Observer $observer
+     *
+     * @throws Mage_Core_Exception
+     */
     public function execute(Varien_Event_Observer $observer)
     {
         $this->_updateSmartcalcs();
         $this->_updateBackupRates();
     }
 
+    /**
+     * @throws Mage_Core_Exception
+     */
     private function _updateSmartcalcs()
     {
-        $enabled = Mage::getStoreConfig('tax/taxjar/enabled');
-        $prevEnabled = Mage::app()->getCache()->load('taxjar_salestax_config_enabled');
+        // UPDATE NOTE: check config for store or website if selected,
+        // fallback to admin scope
+        $enabled = $this->getConfigValue(self::CONFIG_ENABLED);
+        // load cache for currently selected scope
+        $prevEnabled = Mage::app()->getCache()->load(Enabled::CACHE_KEY . '_' . $this->getScopeCode());
 
         if (isset($prevEnabled)) {
-            if ($prevEnabled != $enabled && $enabled == 1) {
+            if ($prevEnabled !== $enabled && (int) $enabled === 1) {
                 Mage::dispatchEvent('taxjar_salestax_import_categories');
                 Mage::dispatchEvent('taxjar_salestax_import_data');
             }
         }
+        // END UPDATE
     }
 
+    /**
+     * @throws Mage_Core_Exception
+     */
     private function _updateBackupRates()
     {
-        $enabled = Mage::getStoreConfig('tax/taxjar/backup');
-        $prevEnabled = Mage::app()->getCache()->load('taxjar_salestax_config_backup');
+        // UPDATE NOTE: check config for store or website if selected,
+        // fallback to admin scope
+        $enabled = $this->getConfigValue(self::CONFIG_BACKUP);
+        // load cache for currently selected scope
+        $prevEnabled = Mage::app()->getCache()->load(Backup::CACHE_KEY . '_' . $this->getScopeCode());
 
         if (isset($prevEnabled)) {
-            if ($prevEnabled != $enabled) {
+            if ($prevEnabled !== $enabled) {
                 Mage::dispatchEvent('taxjar_salestax_import_categories');
                 Mage::dispatchEvent('taxjar_salestax_import_data');
                 Mage::dispatchEvent('taxjar_salestax_import_rates');
             }
         }
+        // END UPDATE
     }
 }

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportData.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportData.php
@@ -17,6 +17,8 @@
 
 class Taxjar_SalesTax_Model_Observer_ImportData
 {
+    use Taxjar_SalesTax_Trait_ConfigScope;
+
     protected $_apiKey;
     protected $_client;
 
@@ -29,7 +31,8 @@ class Taxjar_SalesTax_Model_Observer_ImportData
                 ->load($this->_client->getStoreRegionId());
             $storeRegionCode = $storeRegion->getCode();
 
-            if (isset($storeRegionCode) && $storeRegion->getCountryId() === 'US') {
+            $enabled = $this->getConfigValue('tax/taxjar/enabled');
+            if ($enabled && isset($storeRegionCode) && $storeRegion->getCountryId() === 'US') {
                 $this->_setConfiguration();
             }
         }

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
@@ -17,6 +17,8 @@
 
 class Taxjar_SalesTax_Model_Observer_ImportRates
 {
+    use Taxjar_SalesTax_Trait_ConfigScope;
+
     protected $_apiKey;
     protected $_client;
     protected $_storeZip;
@@ -28,7 +30,7 @@ class Taxjar_SalesTax_Model_Observer_ImportRates
 
     public function execute($ignoredObserverOrCronParameter = null)
     {
-        $isEnabled = Mage::getStoreConfig('tax/taxjar/backup');
+        $isEnabled = $this->getConfigValue('tax/taxjar/backup');
         $this->_apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));
 
         if ($isEnabled && $this->_apiKey) {

--- a/app/code/community/Taxjar/SalesTax/Trait/ConfigScope.php
+++ b/app/code/community/Taxjar/SalesTax/Trait/ConfigScope.php
@@ -1,0 +1,73 @@
+<?php
+
+trait Taxjar_SalesTax_Trait_ConfigScope
+{
+    protected static $_scope;
+    protected static $_scopeCode;
+    protected static $_scopeId;
+
+    /**
+     * Scope in core_config_data table
+     *
+     * @return string
+     */
+    public function getScope()
+    {
+        if (!static::$_scope) {
+            static::$_scope = Mage::getSingleton('adminhtml/config_data')->getScope();
+        }
+
+        return static::$_scope;
+    }
+
+    /**
+     * Scope_id in core_config_data table
+     *
+     * @return int
+     */
+    public function getScopeId()
+    {
+        if (!static::$_scopeId) {
+            static::$_scopeId = Mage::getSingleton('adminhtml/config_data')->getScopeId();
+        }
+
+        return static::$_scopeId;
+    }
+
+    /**
+     * Store or website code, admin if both are empty
+     *
+     * @return string
+     */
+    public function getScopeCode()
+    {
+        if (!static::$_scopeCode) {
+            static::$_scopeCode = Mage::getSingleton('adminhtml/config_data')->getScopeCode() ?: 'admin';
+        }
+
+        return static::$_scopeCode;
+    }
+
+    /**
+     * @param string $configPath
+     *
+     * @return mixed
+     * @throws Mage_Core_Exception
+     */
+    protected function getConfigValue($configPath)
+    {
+        $storeScope = Mage::getSingleton('adminhtml/config_data')->getStore();
+        $websiteScope = Mage::getSingleton('adminhtml/config_data')->getWebsite();
+
+        // fallback to default if more specific scopes are not defined
+        if ($storeScope) {
+            $enabled = Mage::getStoreConfig($configPath, $storeScope);
+        } elseif ($websiteScope) {
+            $enabled = Mage::app()->getWebsite($websiteScope)->getConfig($configPath);
+        } else {
+            $enabled = Mage::getStoreConfig($configPath);
+        }
+
+        return $enabled;
+    }
+}


### PR DESCRIPTION
Save and load TaxJar configs based on current scope instead of global scope.
Apply config changes to TaxJar enabled stores only.